### PR TITLE
Pull request for WAZO-2560-use-python-client-tenant-uuid

### DIFF
--- a/wazo_call_logd_client/commands/agent_statistics.py
+++ b/wazo_call_logd_client/commands/agent_statistics.py
@@ -1,17 +1,19 @@
 # -*- coding: utf-8 -*-
-# Copyright 2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2020-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from wazo_call_logd_client.command import CallLogdCommand
+from .helpers.base import BaseCommand
 
 
-class AgentStatisticsCommand(CallLogdCommand):
+class AgentStatisticsCommand(BaseCommand):
 
     def get_by_id(self, agent_id, **params):
         if 'from_' in params:
             params['from'] = params.pop('from_')
 
-        r = self.session.get(self._client.url('agents', agent_id, 'statistics'), params=params)
+        headers = self._get_headers()
+        url = self._client.url('agents', agent_id, 'statistics')
+        r = self.session.get(url, params=params, headers=headers)
         self.raise_from_response(r)
         return r.json()
 
@@ -19,6 +21,8 @@ class AgentStatisticsCommand(CallLogdCommand):
         if 'from_' in params:
             params['from'] = params.pop('from_')
 
-        r = self.session.get(self._client.url('agents', 'statistics'), params=params)
+        headers = self._get_headers()
+        url = self._client.url('agents', 'statistics')
+        r = self.session.get(url, params=params, headers=headers)
         self.raise_from_response(r)
         return r.json()

--- a/wazo_call_logd_client/commands/cdr.py
+++ b/wazo_call_logd_client/commands/cdr.py
@@ -8,12 +8,15 @@ from wazo_call_logd_client.command import CallLogdCommand
 class CDRCommand(CallLogdCommand):
 
     def get_by_id(self, cdr_id):
-        r = self.session.get(self._client.url('cdr', cdr_id))
+        url = self._client.url('cdr', cdr_id)
+        r = self.session.get(url)
         self.raise_from_response(r)
         return r.json()
 
     def get_by_id_csv(self, cdr_id):
-        r = self.session.get(self._client.url('cdr', cdr_id), headers={'Accept': 'text/csv; charset=utf-8'})
+        headers = {'Accept': 'text/csv; charset=utf-8'}
+        url = self._client.url('cdr', cdr_id)
+        r = self.session.get(url, headers=headers)
         self.raise_from_response(r)
         return r.text
 
@@ -21,7 +24,8 @@ class CDRCommand(CallLogdCommand):
         if 'from_' in params:
             params['from'] = params.pop('from_')
 
-        r = self.session.get(self._client.url('cdr'), params=params)
+        url = self._client.url('cdr')
+        r = self.session.get(url, params=params)
         self.raise_from_response(r)
         return r.json()
 
@@ -29,7 +33,9 @@ class CDRCommand(CallLogdCommand):
         if 'from_' in params:
             params['from'] = params.pop('from_')
 
-        r = self.session.get(self._client.url('cdr'), params=params, headers={'Accept': 'text/csv; charset=utf-8'})
+        headers = {'Accept': 'text/csv; charset=utf-8'}
+        url = self._client.url('cdr')
+        r = self.session.get(url, params=params, headers=headers)
         self.raise_from_response(r)
         return r.text
 
@@ -37,7 +43,8 @@ class CDRCommand(CallLogdCommand):
         if 'from_' in params:
             params['from'] = params.pop('from_')
 
-        r = self.session.get(self._client.url('users', user_uuid, 'cdr'), params=params)
+        url = self._client.url('users', user_uuid, 'cdr')
+        r = self.session.get(url, params=params)
         self.raise_from_response(r)
         return r.json()
 
@@ -45,7 +52,9 @@ class CDRCommand(CallLogdCommand):
         if 'from_' in params:
             params['from'] = params.pop('from_')
 
-        r = self.session.get(self._client.url('users', user_uuid, 'cdr'), params=params, headers={'Accept': 'text/csv; charset=utf-8'})
+        headers = {'Accept': 'text/csv; charset=utf-8'}
+        url = self._client.url('users', user_uuid, 'cdr')
+        r = self.session.get(url, params=params, headers=headers)
         self.raise_from_response(r)
         return r.text
 
@@ -53,7 +62,8 @@ class CDRCommand(CallLogdCommand):
         if 'from_' in params:
             params['from'] = params.pop('from_')
 
-        r = self.session.get(self._client.url('users', 'me', 'cdr'), params=params)
+        url = self._client.url('users', 'me', 'cdr')
+        r = self.session.get(url, params=params)
         self.raise_from_response(r)
         return r.json()
 
@@ -61,7 +71,9 @@ class CDRCommand(CallLogdCommand):
         if 'from_' in params:
             params['from'] = params.pop('from_')
 
-        r = self.session.get(self._client.url('users', 'me', 'cdr'), params=params, headers={'Accept': 'text/csv; charset=utf-8'})
+        headers = {'Accept': 'text/csv; charset=utf-8'}
+        url = self._client.url('users', 'me', 'cdr')
+        r = self.session.get(url, params=params, headers=headers)
         self.raise_from_response(r)
         return r.text
 

--- a/wazo_call_logd_client/commands/cdr.py
+++ b/wazo_call_logd_client/commands/cdr.py
@@ -2,14 +2,15 @@
 # Copyright 2017-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from wazo_call_logd_client.command import CallLogdCommand
+from .helpers.base import BaseCommand
 
 
-class CDRCommand(CallLogdCommand):
+class CDRCommand(BaseCommand):
 
     def get_by_id(self, cdr_id):
+        headers = self._get_headers()
         url = self._client.url('cdr', cdr_id)
-        r = self.session.get(url)
+        r = self.session.get(url, headers=headers)
         self.raise_from_response(r)
         return r.json()
 
@@ -24,8 +25,9 @@ class CDRCommand(CallLogdCommand):
         if 'from_' in params:
             params['from'] = params.pop('from_')
 
+        headers = self._get_headers()
         url = self._client.url('cdr')
-        r = self.session.get(url, params=params)
+        r = self.session.get(url, params=params, headers=headers)
         self.raise_from_response(r)
         return r.json()
 
@@ -43,8 +45,9 @@ class CDRCommand(CallLogdCommand):
         if 'from_' in params:
             params['from'] = params.pop('from_')
 
+        headers = self._get_headers()
         url = self._client.url('users', user_uuid, 'cdr')
-        r = self.session.get(url, params=params)
+        r = self.session.get(url, params=params, headers=headers)
         self.raise_from_response(r)
         return r.json()
 
@@ -62,8 +65,9 @@ class CDRCommand(CallLogdCommand):
         if 'from_' in params:
             params['from'] = params.pop('from_')
 
+        headers = self._get_headers()
         url = self._client.url('users', 'me', 'cdr')
-        r = self.session.get(url, params=params)
+        r = self.session.get(url, params=params, headers=headers)
         self.raise_from_response(r)
         return r.json()
 
@@ -78,30 +82,22 @@ class CDRCommand(CallLogdCommand):
         return r.text
 
     def delete_cdrs_recording_media(self, cdr_ids, **kwargs):
-        tenant_uuid = kwargs.pop('tenant_uuid', None) or self._client.tenant()
-        headers = {}
-        if tenant_uuid:
-            headers['Wazo-Tenant'] = tenant_uuid
+        headers = self._get_headers(**kwargs)
         url = self._client.url('cdr', 'recordings', 'media')
         body = {'cdr_ids': cdr_ids}
         r = self.session.delete(url, json=body, headers=headers)
         self.raise_from_response(r)
 
     def get_recording_media(self, cdr_id, recording_uuid, **kwargs):
-        tenant_uuid = kwargs.pop('tenant_uuid', None) or self._client.tenant()
-        headers = {'Accept': '*/*'}
-        if tenant_uuid:
-            headers['Wazo-Tenant'] = tenant_uuid
+        headers = self._get_headers(**kwargs)
+        headers['Accept'] = '*/*'
         url = self._client.url('cdr', cdr_id, 'recordings', recording_uuid, 'media')
         r = self.session.get(url, headers=headers)
         self.raise_from_response(r)
         return r
 
     def delete_recording_media(self, cdr_id, recording_uuid, **kwargs):
-        tenant_uuid = kwargs.pop('tenant_uuid', None) or self._client.tenant()
-        headers = {}
-        if tenant_uuid:
-            headers['Wazo-Tenant'] = tenant_uuid
+        headers = self._get_headers(**kwargs)
         url = self._client.url('cdr', cdr_id, 'recordings', recording_uuid, 'media')
         r = self.session.delete(url, headers=headers)
         self.raise_from_response(r)
@@ -109,10 +105,7 @@ class CDRCommand(CallLogdCommand):
     def export_recording_media(self, cdr_ids=None, **params):
         if 'from_' in params:
             params['from'] = params.pop('from_')
-        tenant_uuid = params.pop('tenant_uuid', None) or self._client.tenant()
-        headers = {}
-        if tenant_uuid:
-            headers['Wazo-Tenant'] = tenant_uuid
+        headers = self._get_headers(**params)
         body = {}
         if cdr_ids:
             body['cdr_ids'] = cdr_ids

--- a/wazo_call_logd_client/commands/config.py
+++ b/wazo_call_logd_client/commands/config.py
@@ -2,7 +2,6 @@
 # Copyright 2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-
 from .helpers.base import BaseCommand
 
 
@@ -16,9 +15,8 @@ class ConfigCommand(BaseCommand):
         return r.json()
 
     def patch(self, config_patch):
-        headers = self._get_headers(write=True)
-        r = self.session.patch(
-            self._client.url('config'), headers=headers, json=config_patch
-        )
+        headers = self._get_headers()
+        url = self._client.url('config')
+        r = self.session.patch(url, headers=headers, json=config_patch)
         self.raise_from_response(r)
         return r.json()

--- a/wazo_call_logd_client/commands/helpers/base.py
+++ b/wazo_call_logd_client/commands/helpers/base.py
@@ -6,11 +6,10 @@ from wazo_call_logd_client.command import CallLogdCommand
 
 class BaseCommand(CallLogdCommand):
 
-    _ro_headers = {'Accept': 'application/json'}
-    _rw_headers = {'Accept': 'application/json', 'Content-Type': 'application/json'}
+    _headers = {'Accept': 'application/json'}
 
-    def _get_headers(self, write=False, **kwargs):
-        headers = dict(self._rw_headers) if write else dict(self._ro_headers)
+    def _get_headers(self, **kwargs):
+        headers = dict(self._headers)
         tenant_uuid = kwargs.pop('tenant_uuid', self._client.tenant())
         if tenant_uuid:
             headers['Wazo-Tenant'] = tenant_uuid

--- a/wazo_call_logd_client/commands/queue_statistics.py
+++ b/wazo_call_logd_client/commands/queue_statistics.py
@@ -1,17 +1,19 @@
 # -*- coding: utf-8 -*-
-# Copyright 2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2020-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from wazo_call_logd_client.command import CallLogdCommand
+from .helpers.base import BaseCommand
 
 
-class QueueStatisticsCommand(CallLogdCommand):
+class QueueStatisticsCommand(BaseCommand):
 
     def get_by_id(self, queue_id, **params):
         if 'from_' in params:
             params['from'] = params.pop('from_')
 
-        r = self.session.get(self._client.url('queues', queue_id, 'statistics'), params=params)
+        headers = self._get_headers()
+        url = self._client.url('queues', queue_id, 'statistics')
+        r = self.session.get(url, params=params, headers=headers)
         self.raise_from_response(r)
         return r.json()
 
@@ -19,7 +21,9 @@ class QueueStatisticsCommand(CallLogdCommand):
         if 'from_' in params:
             params['from'] = params.pop('from_')
 
-        r = self.session.get(self._client.url('queues', 'statistics'), params=params)
+        headers = self._get_headers()
+        url = self._client.url('queues', 'statistics')
+        r = self.session.get(url, params=params, headers=headers)
         self.raise_from_response(r)
         return r.json()
 
@@ -27,8 +31,8 @@ class QueueStatisticsCommand(CallLogdCommand):
         if 'from_' in params:
             params['from'] = params.pop('from_')
 
-        r = self.session.get(
-            self._client.url('queues', queue_id, 'statistics', 'qos'), params=params
-        )
+        headers = self._get_headers()
+        url = self._client.url('queues', queue_id, 'statistics', 'qos')
+        r = self.session.get(url, params=params, headers=headers)
         self.raise_from_response(r)
         return r.json()

--- a/wazo_call_logd_client/commands/retention.py
+++ b/wazo_call_logd_client/commands/retention.py
@@ -15,7 +15,7 @@ class RetentionCommand(BaseCommand):
         return r.json()
 
     def update(self, tenant_uuid=None, **body):
-        headers = self._get_headers(write=True, tenant_uuid=tenant_uuid)
+        headers = self._get_headers(tenant_uuid=tenant_uuid)
         url = self._client.url('retention')
         r = self.session.put(url, json=body, headers=headers)
         self.raise_from_response(r)

--- a/wazo_call_logd_client/commands/status.py
+++ b/wazo_call_logd_client/commands/status.py
@@ -1,13 +1,15 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from wazo_call_logd_client.command import CallLogdCommand
+from .helpers.base import BaseCommand
 
 
-class StatusCommand(CallLogdCommand):
+class StatusCommand(BaseCommand):
 
     def get(self):
-        r = self.session.get(self._client.url('status'))
+        headers = self._get_headers()
+        url = self._client.url('status')
+        r = self.session.get(url, headers=headers)
         self.raise_from_response(r)
         return r.json()


### PR DESCRIPTION
do not use deprecated python client method

Depends-on: https://github.com/wazo-platform/wazo-lib-rest-client/pull/10